### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,6 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@antelopejs/interface-api": "^0.0.2",
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.3",
     "@antelopejs/interface-database": "^0.0.2",
     "randomstring": "^1.3.1",
     "reflect-metadata": "^0.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       '@antelopejs/interface-database':
         specifier: ^0.0.2
         version: 0.0.2
@@ -68,6 +68,9 @@ packages:
 
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@antelopejs/interface-database@0.0.2':
     resolution: {integrity: sha512-SFqPwHZf1Qh1Zfcdu1CSBh5/uqT2jEczMtERcOChQYAiEKN+XwStwVttAY7yy/TKd3frqjZ3GrwKK1qXxqx7qQ==}
@@ -603,6 +606,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1403,6 +1409,10 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
+  '@antelopejs/interface-core@0.0.3':
+    dependencies:
+      reflect-metadata: 0.2.2
+
   '@antelopejs/interface-database@0.0.2':
     dependencies:
       '@antelopejs/interface-core': 0.0.2
@@ -1757,7 +1767,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1901,6 +1911,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -2003,7 +2015,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Remove wildcard subpath exports (`./*`) to hide internal dist paths from consumers
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the wildcard subpath export (`./*`) from `package.json` to encapsulate internal `dist/` paths from package consumers, and bumps `@antelopejs/interface-core` from `^0.0.2` to `^0.0.3`. The lockfile is updated accordingly, including a transitive bump of `defu` to `6.1.7`. Removing the wildcard export is technically a breaking change for any consumer importing internal subpaths (e.g. `@antelopejs/interface-database-decorators/some-module`), though the package is pre-`1.0` so this is expected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely maintenance with no logic or functional regressions.

Both changes are intentional and correctly applied: the wildcard export removal is a deliberate encapsulation decision, and the dependency bump is reflected consistently in both `package.json` and the lockfile. No logic, tests, or source files are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard subpath export `./*` to hide internal dist paths, and bumps `@antelopejs/interface-core` to `^0.0.3` |
| pnpm-lock.yaml | Lockfile updated to reflect `@antelopejs/interface-core@0.0.3` and a transitive bump of `defu` from `6.1.4` to `6.1.7` |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer imports package] --> B{Which subpath?}
    B -->|Root import| C[dist/index.js - allowed]
    B -->|package.json| D[package.json - allowed]
    B -->|Any other subpath| E[Not exported - blocked by wildcard removal]
    style E fill:#f88,color:#000
    style C fill:#8f8,color:#000
    style D fill:#8f8,color:#000
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-database-decorators/commit/997cd8a810690193c32493bcb8e930a6cd0e3f8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29166888)</sub>

<!-- /greptile_comment -->