### PR TITLE
feat!: rename CreateDatabaseSchemaInstance to RegisterSchema and add @TenantScoped

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,42 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./common": {
+      "types": "./dist/common.d.ts",
+      "default": "./dist/common.js"
+    },
+    "./database": {
+      "types": "./dist/database.d.ts",
+      "default": "./dist/database.js"
+    },
+    "./model": {
+      "types": "./dist/model.d.ts",
+      "default": "./dist/model.js"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "default": "./dist/schema.js"
+    },
+    "./table": {
+      "types": "./dist/table.d.ts",
+      "default": "./dist/table.js"
+    },
+    "./modifiers/common": {
+      "types": "./dist/modifiers/common.d.ts",
+      "default": "./dist/modifiers/common.js"
+    },
+    "./modifiers/encryption": {
+      "types": "./dist/modifiers/encryption.d.ts",
+      "default": "./dist/modifiers/encryption.js"
+    },
+    "./modifiers/hash": {
+      "types": "./dist/modifiers/hash.d.ts",
+      "default": "./dist/modifiers/hash.js"
+    },
+    "./modifiers/localization": {
+      "types": "./dist/modifiers/localization.d.ts",
+      "default": "./dist/modifiers/localization.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -39,7 +75,7 @@
   "dependencies": {
     "@antelopejs/interface-api": "^0.0.3",
     "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-database": "^0.0.4",
+    "@antelopejs/interface-database": "^0.1.0",
     "randomstring": "^1.3.1",
     "reflect-metadata": "^0.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3
       '@antelopejs/interface-database':
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.1.0
+        version: 0.1.0
       randomstring:
         specifier: ^1.3.1
         version: 1.3.1
@@ -69,8 +69,8 @@ packages:
   '@antelopejs/interface-core@0.0.3':
     resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
-  '@antelopejs/interface-database@0.0.4':
-    resolution: {integrity: sha512-cO0YmhtQyaJlDNVf/Zgp2D3Iqw5xaQnPn318E5llQ9lDVB8LdNW4KNPv0namk9s7CK/PHI6XKRNoZ1ifcLOBUQ==}
+  '@antelopejs/interface-database@0.1.0':
+    resolution: {integrity: sha512-6r+f5A6fttYrQyUh7NnRJxOaNjgsKpb3CeROIQGB7z5EB1vsxgOji8X3CBXflZeEIPlueMuw+YKv1e5+LE6hDg==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1406,7 +1406,7 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.0.4':
+  '@antelopejs/interface-database@0.1.0':
     dependencies:
       '@antelopejs/interface-core': 0.0.3
 

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -11,14 +11,14 @@ export default defineConfig({
       source: {
         type: "package",
         package: "@antelopejs/mongodb",
-        version: "1.0.0",
+        version: "1.1.0",
       },
     },
     database_decorators: {
       source: {
         type: "package",
         package: "@antelopejs/database-decorators",
-        version: "1.0.0",
+        version: "1.1.0",
       },
     },
     api: {

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,6 +35,7 @@ export class DatumStaticMetadata {
   public readonly indexes: Record<string, Array<string>> = {};
   public primary: string = "_id";
   public generator?: DatumGenerator;
+  public tenantScoped: boolean = false;
 
   addIndex(key: string, group: string) {
     if (!(group in this.indexes)) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -57,7 +57,7 @@ function buildSchemaDefinition(tables: TableDefinitions): SchemaDefinition {
     definition[tableName] = {
       fields: {},
       indexes,
-      tenantScoped: metadata.tenantScoped || undefined,
+      tenantScoped: metadata.tenantScoped ? true : undefined,
     };
   }
   return definition;

--- a/src/database.ts
+++ b/src/database.ts
@@ -15,9 +15,24 @@ import type { Table } from "./table";
 type TableDefinitions = Record<string, Class<Table>>;
 type TableEntry = Record<string, unknown>;
 
-export async function CreateDatabaseSchemaInstance(
+/**
+ * Registers a schema with the database adapter and runs any fixtures.
+ *
+ * Reads the table classes registered for `schemaId` via `@RegisterTable`,
+ * builds a `SchemaDefinition` (including the per-table `tenantScoped` flag
+ * set by `@TenantScoped`), constructs the `Schema` (which the adapter
+ * provisions in its physical store), then inserts fixtures for any
+ * non-tenant-scoped table that declares one.
+ *
+ * Tenant-scoped tables cannot carry fixtures: there is no global tenant id
+ * to stamp them with. Boot-time seeding of tenant data should be done via
+ * an explicit "create tenant" hook in the application.
+ *
+ * @param schemaId Schema id matching the `@RegisterTable(_, schemaId)` calls
+ * @param options  Schema options (e.g. `physicalStore`)
+ */
+export async function RegisterSchema(
   schemaId: string,
-  instanceId?: string,
   options?: SchemaOptions,
 ): Promise<void> {
   const tables = getTablesForSchema(schemaId);
@@ -25,9 +40,8 @@ export async function CreateDatabaseSchemaInstance(
 
   const definition = buildSchemaDefinition(tables);
   const schema = new Schema(schemaId, definition, options);
-  await schema.createInstance(instanceId);
 
-  await insertAllFixtureData(schema, instanceId, tables);
+  await insertAllFixtureData(schema, tables);
 }
 
 function buildSchemaDefinition(tables: TableDefinitions): SchemaDefinition {
@@ -40,14 +54,17 @@ function buildSchemaDefinition(tables: TableDefinitions): SchemaDefinition {
         fields: fields.length === 1 && fields[0] === group ? undefined : fields,
       };
     }
-    definition[tableName] = { fields: {}, indexes };
+    definition[tableName] = {
+      fields: {},
+      indexes,
+      tenantScoped: metadata.tenantScoped || undefined,
+    };
   }
   return definition;
 }
 
 async function insertAllFixtureData(
   schema: Schema<any>,
-  instanceId: string | undefined,
   tables: TableDefinitions,
 ): Promise<void> {
   await Promise.all(
@@ -55,9 +72,9 @@ async function insertAllFixtureData(
       const metadata = getMetadata(tableClass, DatumStaticMetadata);
       return insertFixtureData(
         schema,
-        instanceId,
         tableName,
         tableClass,
+        metadata.tenantScoped,
         metadata.generator,
       );
     }),
@@ -66,15 +83,19 @@ async function insertAllFixtureData(
 
 async function insertFixtureData(
   schema: Schema<any>,
-  instanceId: string | undefined,
   tableName: string,
   tableClass: Class<Table>,
+  tenantScoped: boolean,
   generator: DatumStaticMetadata["generator"],
 ): Promise<void> {
   if (!generator) {
     return;
   }
-  const count = await schema.instance(instanceId).table(tableName).count();
+  assert(
+    !tenantScoped,
+    `Fixture on tenant-scoped table '${tableName}' is not supported: there is no implicit tenant id at registration time. Seed tenant data from a create-tenant hook instead.`,
+  );
+  const count = await schema.instance().table(tableName).count();
   if (count > 0) {
     return;
   }
@@ -84,7 +105,7 @@ async function insertFixtureData(
     return;
   }
   const payload: any = rows.length === 1 ? rows[0] : rows;
-  await schema.instance(instanceId).table(tableName).insert(payload);
+  await schema.instance().table(tableName).insert(payload);
 }
 
 function toFixtureRows(

--- a/src/model.ts
+++ b/src/model.ts
@@ -182,8 +182,10 @@ const modelCache = new Map<
   Map<string | symbol, InstanceType<DataModel>>
 >();
 
+const UNDEFINED_INSTANCE_KEY = Symbol("undefined-instance");
+
 function cacheKeyOf(instanceId: TenantId | undefined): string | symbol {
-  if (instanceId === undefined) return "";
+  if (instanceId === undefined) return UNDEFINED_INSTANCE_KEY;
   if (typeof instanceId === "symbol") return instanceId;
   return instanceId;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -8,7 +8,7 @@ import {
   MakeParameterAndPropertyDecorator,
 } from "@antelopejs/interface-core/decorators";
 import type * as DatabaseDev from "@antelopejs/interface-database";
-import { Schema } from "@antelopejs/interface-database";
+import { Schema, type TenantId } from "@antelopejs/interface-database";
 import {
   type Constructible,
   DatumStaticMetadata,
@@ -177,22 +177,33 @@ export function BasicDataModel<T extends object>(
   };
 }
 
-const modelCache = new Map<Class, Record<string, InstanceType<DataModel>>>();
+const modelCache = new Map<
+  Class,
+  Map<string | symbol, InstanceType<DataModel>>
+>();
+
+function cacheKeyOf(instanceId: TenantId | undefined): string | symbol {
+  if (instanceId === undefined) return "";
+  if (typeof instanceId === "symbol") return instanceId;
+  return instanceId;
+}
 
 export function GetModel<M extends InstanceType<DataModel>>(
   cl: DataModel & Class<M>,
-  instanceId?: string,
+  instanceId?: TenantId,
 ) {
   if (!modelCache.has(cl)) {
-    modelCache.set(cl, {});
+    modelCache.set(cl, new Map());
   }
-  const cache = modelCache.get(cl) ?? {};
-  const cacheKey = instanceId ?? "";
-  if (cache[cacheKey]) return cache[cacheKey] as M;
+  const cache = modelCache.get(cl);
+  assert(cache);
+  const key = cacheKeyOf(instanceId);
+  const cached = cache.get(key);
+  if (cached) return cached as M;
   const schema = Schema.get(cl.schemaName);
   assert(schema, `Schema not found for '${cl.schemaName}'`);
   const model = new cl(schema.instance(instanceId));
-  cache[cacheKey] = model;
+  cache.set(key, model);
   return model;
 }
 
@@ -203,8 +214,8 @@ export const Model = MakeParameterAndPropertyDecorator(
     index,
     cl: DataModel & Class<InstanceType<DataModel>>,
     instanceIdOrCallback?:
-      | string
-      | ((ctx: RequestContext) => string | undefined),
+      | TenantId
+      | ((ctx: RequestContext) => TenantId | undefined),
   ) => {
     if (typeof instanceIdOrCallback === "function") {
       SetParameterProvider(target, key, index, (ctx: RequestContext) => {

--- a/src/table.ts
+++ b/src/table.ts
@@ -121,3 +121,19 @@ export const Fixture: <T extends typeof Table>(
   const metadata = getMetadata(target, DatumStaticMetadata);
   metadata.generator = generator as unknown as DatumStaticMetadata["generator"];
 });
+
+/**
+ * Marks a Table as tenant-scoped.
+ *
+ * Implementations stamp `tenant_id` on insert, filter reads/updates/deletes
+ * on it, and reject queries that omit a tenant context (`Schema.instance(id)`).
+ *
+ * The query path supports a `CROSS_TENANT` sentinel for legitimate admin
+ * operations that need to span every tenant; see `@antelopejs/interface-database`
+ * for the contract.
+ */
+export const TenantScoped: () => ClassDecorator<typeof Table> =
+  MakeClassDecorator((target) => {
+    const metadata = getMetadata(target, DatumStaticMetadata);
+    metadata.tenantScoped = true;
+  });

--- a/src/tests/database.test.ts
+++ b/src/tests/database.test.ts
@@ -1,15 +1,16 @@
 import { Schema } from "@antelopejs/interface-database";
-import { CreateDatabaseSchemaInstance } from "@antelopejs/interface-database-decorators/database";
+import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
 import { RegisterTable } from "@antelopejs/interface-database-decorators/schema";
 import {
   Fixture,
   Index,
   Table,
+  TenantScoped,
 } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
 
 describe("Database - initialization", () => {
-  it("creates a schema instance", async () => CreateSchemaInstanceTest());
+  it("creates a schema", async () => CreateSchemaTest());
   it("creates tables with default primary key", async () =>
     CreateTablesWithDefaultPrimaryKeyTest());
   it("creates tables with indexes", async () => CreateTablesWithIndexesTest());
@@ -18,19 +19,21 @@ describe("Database - initialization", () => {
   it("creates tables with fixture data", async () =>
     CreateTablesWithFixtureDataTest());
   it("handles multiple tables", async () => HandleMultipleTablesTest());
-  it("creates multiple instances for same schema", async () =>
-    CreateMultipleInstancesTest());
-  it("inserts fixtures for each instance", async () =>
-    InsertFixturesForEachInstanceTest());
+  it("co-locates schemas via shared physicalStore", async () =>
+    SharedPhysicalStoreTest());
+  it("rejects fixtures on tenant-scoped tables", async () =>
+    RejectsFixturesOnTenantScopedTablesTest());
+  it("propagates tenantScoped flag to schema definition", async () =>
+    PropagatesTenantScopedFlagTest());
 });
 
-async function CreateSchemaInstanceTest() {
+async function CreateSchemaTest() {
   @RegisterTable("test_table", "test-new-schema")
   class _TestTable extends Table {
     declare name: string;
   }
 
-  await CreateDatabaseSchemaInstance("test-new-schema", "test-new-instance");
+  await RegisterSchema("test-new-schema");
 
   const schema = Schema.get("test-new-schema");
   expect(schema).to.not.equal(undefined);
@@ -42,7 +45,7 @@ async function CreateTablesWithDefaultPrimaryKeyTest() {
     declare name: string;
   }
 
-  await CreateDatabaseSchemaInstance("test-pk-schema", "test-pk-instance");
+  await RegisterSchema("test-pk-schema");
 
   const schema = Schema.get("test-pk-schema");
   expect(schema).to.not.equal(undefined);
@@ -58,7 +61,7 @@ async function CreateTablesWithIndexesTest() {
     declare email: string;
   }
 
-  await CreateDatabaseSchemaInstance("test-idx-schema", "test-idx-instance");
+  await RegisterSchema("test-idx-schema");
 
   const schema = Schema.get("test-idx-schema");
   expect(schema).to.not.equal(undefined);
@@ -77,7 +80,7 @@ async function CreateTablesWithGroupedIndexesTest() {
     declare age: number;
   }
 
-  await CreateDatabaseSchemaInstance("test-grp-schema", "test-grp-instance");
+  await RegisterSchema("test-grp-schema");
 
   const schema = Schema.get("test-grp-schema");
   expect(schema).to.not.equal(undefined);
@@ -95,16 +98,11 @@ async function CreateTablesWithFixtureDataTest() {
     declare name: string;
   }
 
-  await CreateDatabaseSchemaInstance(
-    "test-fixture-schema",
-    "test-fixture-instance",
-  );
+  await RegisterSchema("test-fixture-schema");
 
   const schema = Schema.get("test-fixture-schema");
   if (!schema) throw new Error("Schema not found");
-  const result = await schema
-    .instance("test-fixture-instance")
-    .table("fixture_table");
+  const result = await schema.instance().table("fixture_table");
   for (const val of result) {
     delete val._id;
   }
@@ -129,74 +127,67 @@ async function HandleMultipleTablesTest() {
     declare price: number;
   }
 
-  await CreateDatabaseSchemaInstance(
-    "test-multi-table-schema",
-    "test-multi-table-instance",
-  );
+  await RegisterSchema("test-multi-table-schema");
 
   const schema = Schema.get("test-multi-table-schema");
   expect(schema).to.not.equal(undefined);
 }
 
-async function CreateMultipleInstancesTest() {
-  @RegisterTable("tenant_table", "test-multi-instance-schema")
+async function SharedPhysicalStoreTest() {
+  @RegisterTable("global_table", "test-store-global")
+  class _GlobalTable extends Table {
+    declare name: string;
+  }
+
+  @RegisterTable("tenant_table", "test-store-tenant")
+  @TenantScoped()
   class _TenantTable extends Table {
     declare name: string;
   }
 
-  await CreateDatabaseSchemaInstance("test-multi-instance-schema", "tenant-1");
-  await CreateDatabaseSchemaInstance("test-multi-instance-schema", "tenant-2");
+  await RegisterSchema("test-store-global", { physicalStore: "test-shared" });
+  await RegisterSchema("test-store-tenant", { physicalStore: "test-shared" });
 
-  const schema1 = Schema.get("test-multi-instance-schema");
-  const schema2 = Schema.get("test-multi-instance-schema");
-  expect(schema1).to.not.equal(undefined);
-  expect(schema2).to.not.equal(undefined);
-  expect(schema1).to.equal(schema2);
-
-  const instance1 = schema1?.instance("tenant-1");
-  const instance2 = schema2?.instance("tenant-2");
-  expect(instance1).to.not.equal(undefined);
-  expect(instance2).to.not.equal(undefined);
+  const globalSchema = Schema.get("test-store-global");
+  const tenantSchema = Schema.get("test-store-tenant");
+  expect(globalSchema).to.not.equal(undefined);
+  expect(tenantSchema).to.not.equal(undefined);
+  expect(globalSchema?.options.physicalStore).to.equal("test-shared");
+  expect(tenantSchema?.options.physicalStore).to.equal("test-shared");
 }
 
-async function InsertFixturesForEachInstanceTest() {
-  const testData = [
-    { id: "1", name: "Fixture 1" },
-    { id: "2", name: "Fixture 2" },
-  ];
-
-  @Fixture(() => testData)
-  @RegisterTable("fixture_multi", "test-fixture-multi-schema")
-  class _FixtureTable extends Table {
+async function RejectsFixturesOnTenantScopedTablesTest() {
+  @Fixture(() => [{ name: "boom" }])
+  @TenantScoped()
+  @RegisterTable("forbidden_fixture", "test-fixture-tenant-schema")
+  class _ForbiddenTable extends Table {
     declare name: string;
   }
 
-  await CreateDatabaseSchemaInstance(
-    "test-fixture-multi-schema",
-    "fixture-inst-1",
-  );
-  await CreateDatabaseSchemaInstance(
-    "test-fixture-multi-schema",
-    "fixture-inst-2",
-  );
-
-  const schema = Schema.get("test-fixture-multi-schema");
-  if (!schema) throw new Error("Schema not found");
-  const sortById = (a: any, b: any) => a.id.localeCompare(b.id);
-
-  const result1 = await schema
-    .instance("fixture-inst-1")
-    .table("fixture_multi");
-  for (const val of result1) {
-    delete val._id;
+  let threw = false;
+  try {
+    await RegisterSchema("test-fixture-tenant-schema");
+  } catch {
+    threw = true;
   }
-  expect(result1.sort(sortById)).to.deep.equal(testData.sort(sortById));
+  expect(threw).to.equal(true);
+}
 
-  const result2 = await schema
-    .instance("fixture-inst-2")
-    .table("fixture_multi");
-  for (const val of result2) {
-    delete val._id;
+async function PropagatesTenantScopedFlagTest() {
+  @RegisterTable("global_only", "test-flag-schema")
+  class _GlobalTable extends Table {
+    declare name: string;
   }
-  expect(result2.sort(sortById)).to.deep.equal(testData.sort(sortById));
+
+  @RegisterTable("tenant_only", "test-flag-schema")
+  @TenantScoped()
+  class _TenantTable extends Table {
+    declare name: string;
+  }
+
+  await RegisterSchema("test-flag-schema");
+
+  const schema = Schema.get("test-flag-schema");
+  expect(schema?.definition.global_only.tenantScoped).to.equal(undefined);
+  expect(schema?.definition.tenant_only.tenantScoped).to.equal(true);
 }

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,5 +1,5 @@
 import { Schema } from "@antelopejs/interface-database";
-import { CreateDatabaseSchemaInstance } from "@antelopejs/interface-database-decorators/database";
+import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
 import { BasicDataModel } from "@antelopejs/interface-database-decorators/model";
 import {
   Encrypted,
@@ -21,10 +21,9 @@ import {
 } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
 
-function getDatabase(schemaId: string, instanceId: string) {
-  const instance = Schema.get(schemaId)?.instance(instanceId);
-  if (!instance)
-    throw new Error(`Database not found: ${schemaId}/${instanceId}`);
+function getDatabase(schemaId: string) {
+  const instance = Schema.get(schemaId)?.instance();
+  if (!instance) throw new Error(`Database not found: ${schemaId}`);
   return instance;
 }
 
@@ -64,14 +63,8 @@ async function CreateAndQueryUserWithModifiersTest() {
 
   const UserModel = BasicDataModel(User, "users");
 
-  await CreateDatabaseSchemaInstance(
-    "integration-modifiers-schema",
-    "test-integration-db",
-  );
-  const schemaInstance = getDatabase(
-    "integration-modifiers-schema",
-    "test-integration-db",
-  );
+  await RegisterSchema("integration-modifiers-schema");
+  const schemaInstance = getDatabase("integration-modifiers-schema");
   const userModel = new UserModel(schemaInstance);
 
   const userData = {
@@ -141,8 +134,8 @@ async function PerformCrudOperationsOnProductsTest() {
 
   const ProductModel = BasicDataModel(Product, "products");
 
-  await CreateDatabaseSchemaInstance("integration-crud-schema", "test-crud-db");
-  const schemaInstance = getDatabase("integration-crud-schema", "test-crud-db");
+  await RegisterSchema("integration-crud-schema");
+  const schemaInstance = getDatabase("integration-crud-schema");
   const productModel = new ProductModel(schemaInstance);
 
   const productData = {
@@ -187,14 +180,8 @@ async function HandleLocalizedContentTest() {
 
   const ContentModel = BasicDataModel(LocalizedContent, "localized_content");
 
-  await CreateDatabaseSchemaInstance(
-    "integration-l10n-schema",
-    "test-localization-db",
-  );
-  const schemaInstance = getDatabase(
-    "integration-l10n-schema",
-    "test-localization-db",
-  );
+  await RegisterSchema("integration-l10n-schema");
+  const schemaInstance = getDatabase("integration-l10n-schema");
   const contentModel = new ContentModel(schemaInstance);
 
   const content = new LocalizedContent();
@@ -243,14 +230,8 @@ async function ManageEncryptedSensitiveDataTest() {
 
   const SensitiveDataModel = BasicDataModel(SensitiveData, "sensitive_data");
 
-  await CreateDatabaseSchemaInstance(
-    "integration-encrypt-schema",
-    "test-encryption-db",
-  );
-  const schemaInstance = getDatabase(
-    "integration-encrypt-schema",
-    "test-encryption-db",
-  );
+  await RegisterSchema("integration-encrypt-schema");
+  const schemaInstance = getDatabase("integration-encrypt-schema");
   const sensitiveDataModel = new SensitiveDataModel(schemaInstance);
 
   const sensitiveData = {
@@ -294,8 +275,8 @@ async function ValidateHashedPasswordsTest() {
 
   const UserAccountModel = BasicDataModel(UserAccount, "user_accounts");
 
-  await CreateDatabaseSchemaInstance("integration-hash-schema", "test-hash-db");
-  const schemaInstance = getDatabase("integration-hash-schema", "test-hash-db");
+  await RegisterSchema("integration-hash-schema");
+  const schemaInstance = getDatabase("integration-hash-schema");
   const userAccountModel = new UserAccountModel(schemaInstance);
 
   const accountData = {
@@ -343,15 +324,9 @@ async function WorkWithSchemaRegistrationTest() {
     declare price: number;
   }
 
-  await CreateDatabaseSchemaInstance(
-    "integration-schema-reg",
-    "test-schema-integration-db",
-  );
+  await RegisterSchema("integration-schema-reg");
 
-  const schemaInstance = getDatabase(
-    "integration-schema-reg",
-    "test-schema-integration-db",
-  );
+  const schemaInstance = getDatabase("integration-schema-reg");
   const UserModel = BasicDataModel(SchemaUser, "schema_users");
   const ProductModel = BasicDataModel(SchemaProduct, "schema_products");
 
@@ -404,14 +379,8 @@ async function HandleComplexRelationshipsTest() {
   const OrderModel = BasicDataModel(Order, "orders");
   const OrderItemModel = BasicDataModel(OrderItem, "order_items");
 
-  await CreateDatabaseSchemaInstance(
-    "integration-rel-schema",
-    "test-relationships-db",
-  );
-  const schemaInstance = getDatabase(
-    "integration-rel-schema",
-    "test-relationships-db",
-  );
+  await RegisterSchema("integration-rel-schema");
+  const schemaInstance = getDatabase("integration-rel-schema");
 
   const orderModel = new OrderModel(schemaInstance);
   const orderItemModel = new OrderItemModel(schemaInstance);
@@ -457,8 +426,8 @@ async function PerformBulkOperationsTest() {
 
   const BulkProductModel = BasicDataModel(BulkProduct, "bulk_products");
 
-  await CreateDatabaseSchemaInstance("integration-bulk-schema", "test-bulk-db");
-  const schemaInstance = getDatabase("integration-bulk-schema", "test-bulk-db");
+  await RegisterSchema("integration-bulk-schema");
+  const schemaInstance = getDatabase("integration-bulk-schema");
   const bulkProductModel = new BulkProductModel(schemaInstance);
 
   const bulkData = [
@@ -501,15 +470,9 @@ async function ManageDatabaseInitializationTest() {
     declare name: string;
   }
 
-  await CreateDatabaseSchemaInstance(
-    "integration-fixture-schema",
-    "test-fixture-db",
-  );
+  await RegisterSchema("integration-fixture-schema");
 
-  const schemaInstance = getDatabase(
-    "integration-fixture-schema",
-    "test-fixture-db",
-  );
+  const schemaInstance = getDatabase("integration-fixture-schema");
   const FixtureUserModel = BasicDataModel(FixtureUser, "fixture_users");
   const fixtureUserModel = new FixtureUserModel(schemaInstance);
 

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -3,6 +3,7 @@ import {
   Get,
   type RequestContext,
 } from "@antelopejs/interface-api";
+import { CROSS_TENANT } from "@antelopejs/interface-database";
 import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
 import {
   BasicDataModel,
@@ -10,7 +11,10 @@ import {
   Model,
 } from "@antelopejs/interface-database-decorators/model";
 import { RegisterTable } from "@antelopejs/interface-database-decorators/schema";
-import { Table } from "@antelopejs/interface-database-decorators/table";
+import {
+  Table,
+  TenantScoped,
+} from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
 
 describe("Model - data operations", () => {
@@ -136,22 +140,26 @@ async function GetModelFromCacheTest() {
 }
 
 async function CreateNewModelWhenNotCachedTest() {
-  @RegisterTable("nocache_table", "model-nocache-schema")
+  @TenantScoped()
+  @RegisterTable("nocache_tenant", "model-nocache-schema")
   class TestTable extends Table {
     name!: string;
   }
 
-  const TestModel = BasicDataModel(TestTable, "nocache_table");
+  const TestModel = BasicDataModel(TestTable, "nocache_tenant");
 
   await RegisterSchema("model-nocache-schema");
-  await RegisterSchema("model-nocache-schema");
 
-  const model1 = GetModel(TestModel, "model-db1");
-  const model2 = GetModel(TestModel, "model-db2");
+  const tenant1 = GetModel(TestModel, "tenant-1");
+  const tenant2 = GetModel(TestModel, "tenant-2");
+  const cross = GetModel(TestModel, CROSS_TENANT);
 
-  expect(model1).to.not.equal(model2);
-  expect(model1).to.be.instanceOf(TestModel);
-  expect(model2).to.be.instanceOf(TestModel);
+  expect(tenant1).to.not.equal(tenant2);
+  expect(tenant1).to.not.equal(cross);
+  expect(tenant2).to.not.equal(cross);
+  expect(tenant1).to.be.instanceOf(TestModel);
+  expect(tenant2).to.be.instanceOf(TestModel);
+  expect(cross).to.be.instanceOf(TestModel);
 }
 
 async function HandleModelWithStringInstanceIdTest() {

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -3,7 +3,7 @@ import {
   Get,
   type RequestContext,
 } from "@antelopejs/interface-api";
-import { CreateDatabaseSchemaInstance } from "@antelopejs/interface-database-decorators/database";
+import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
 import {
   BasicDataModel,
   GetModel,
@@ -126,10 +126,7 @@ async function GetModelFromCacheTest() {
 
   const TestModel = BasicDataModel(TestTable, "cache_table");
 
-  await CreateDatabaseSchemaInstance(
-    "model-cache-schema",
-    "test-model-cache-db",
-  );
+  await RegisterSchema("model-cache-schema");
 
   const model1 = GetModel(TestModel, "test-model-cache-db");
   const model2 = GetModel(TestModel, "test-model-cache-db");
@@ -146,8 +143,8 @@ async function CreateNewModelWhenNotCachedTest() {
 
   const TestModel = BasicDataModel(TestTable, "nocache_table");
 
-  await CreateDatabaseSchemaInstance("model-nocache-schema", "model-db1");
-  await CreateDatabaseSchemaInstance("model-nocache-schema", "model-db2");
+  await RegisterSchema("model-nocache-schema");
+  await RegisterSchema("model-nocache-schema");
 
   const model1 = GetModel(TestModel, "model-db1");
   const model2 = GetModel(TestModel, "model-db2");
@@ -163,10 +160,7 @@ async function HandleModelWithStringInstanceIdTest() {
     name!: string;
   }
   const TestModel = BasicDataModel(TestTable, "static_table");
-  await CreateDatabaseSchemaInstance(
-    "model-static-schema",
-    "test-static-model-db",
-  );
+  await RegisterSchema("model-static-schema");
   class _TestService extends Controller("/staticmodel") {
     @Model(TestModel, "test-static-model-db")
     model!: InstanceType<typeof TestModel>;
@@ -188,10 +182,7 @@ async function HandleModelWithCallbackInstanceIdTest() {
     name!: string;
   }
   const TestModel = BasicDataModel(TestTable, "dynamic_table");
-  await CreateDatabaseSchemaInstance(
-    "model-dynamic-schema",
-    "test-dynamic-model-db",
-  );
+  await RegisterSchema("model-dynamic-schema");
   class _TestService extends Controller("/dynamicmodel/:database") {
     @Model(TestModel, (ctx: RequestContext) => ctx.routeParameters.database)
     model!: InstanceType<typeof TestModel>;


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adopts `@antelopejs/interface-database@^0.1.0`, which removes the per-schema `instanceId` plumbing from registration in favor of an explicit `@TenantScoped()` opt-in on tables.

- **Renamed** `CreateDatabaseSchemaInstance(schemaId, instanceId?, options?)` → `RegisterSchema(schemaId, options?)`. There is no longer a global registration-time tenant id; the function builds the `SchemaDefinition` (now carrying the per-table `tenantScoped` flag) and seeds fixtures.
- **Added** `@TenantScoped()` class decorator (`src/table.ts`). Implementations stamp `tenant_id` on insert, filter reads/updates/deletes on it, and reject queries that omit a tenant context. The query path supports a `CROSS_TENANT` sentinel for legitimate admin operations.
- **Fixtures on tenant-scoped tables are rejected** at registration time with an explicit error (no implicit tenant id to stamp them with). Boot-time tenant data should be seeded from a create-tenant hook.
- **Model/decorator types**: `GetModel` and `@Model` now accept `TenantId` (`string | symbol`) so callers can pass `CROSS_TENANT`. The model cache moved from a plain object to a `Map` to key by symbol safely.
- **package.json**: expose subpath exports for `./common`, `./database`, `./model`, `./schema`, `./table` and `./modifiers/*` so consumers can import from stable entry points (the test suite already does).
- **Tests**: rewritten around the new API — multi-instance tests replaced by a shared-`physicalStore` co-location test, a fixtures-on-tenant-scoped rejection test, and a propagation test for the `tenantScoped` flag in the schema definition. Integration tests no longer pass an `instanceId`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adopts `@antelopejs/interface-database@^0.1.0` by replacing `CreateDatabaseSchemaInstance(schemaId, instanceId?, options?)` with `RegisterSchema(schemaId, options?)` and introducing the `@TenantScoped()` class decorator, which signals per-table tenant isolation to the adapter layer.

- **`RegisterSchema`** removes the global `instanceId` parameter; tenant context is now expressed per-table via `@TenantScoped()`, and the `SchemaDefinition` carries the resulting `tenantScoped` flag. Fixtures on tenant-scoped tables are rejected at registration time via an explicit assertion.
- **`GetModel` / `@Model`** now accept `TenantId` (`string | symbol`) and the model cache was migrated from a plain object to a nested `Map`, enabling symbol keys such as the new `CROSS_TENANT` sentinel.
- **Subpath exports** (`./common`, `./database`, `./model`, `./schema`, `./table`, `./modifiers/*`) are added to `package.json` so consumers can import from stable entry points.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core registration, schema definition, fixture guard, and model-cache changes are all logically sound and covered by targeted tests.

The tenantScoped flag flows correctly from decorator through metadata into SchemaDefinition, and the fixture assertion fires before any DB mutation. The model cache migration to nested Map correctly handles symbol keys (CROSS_TENANT) and the undefined-instance sentinel. No data-loss or auth-boundary issues were found.

No files require special attention; the minor semantic mismatch in GetModelFromCacheTest is test-only and does not affect production behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/database.ts | Renamed to RegisterSchema, dropped instanceId, added tenantScoped propagation and an assert that rejects fixtures on tenant-scoped tables before any DB call |
| src/model.ts | modelCache migrated to nested Map for symbol-safe keying; cacheKeyOf uses a dedicated symbol for undefined; GetModel/Model now accept TenantId (string | symbol) |
| src/table.ts | New @TenantScoped() class decorator that stamps metadata.tenantScoped = true, correctly wired through MakeClassDecorator |
| src/common.ts | Added tenantScoped: boolean = false field to DatumStaticMetadata; backward compatible default |
| src/tests/database.test.ts | Old instance-ID tests replaced with shared-physicalStore, tenant-fixture-rejection, and tenantScoped-flag-propagation tests; all cover new contract well |
| src/tests/model.test.ts | CreateNewModelWhenNotCachedTest now correctly uses @TenantScoped() and CROSS_TENANT; GetModelFromCacheTest still passes a string-typed TenantId to a non-tenant-scoped table, which is a semantic mismatch |
| src/tests/integration.test.ts | Clean mechanical removal of instanceId from all RegisterSchema/getDatabase calls; integration coverage unchanged |
| package.json | Bumped @antelopejs/interface-database to ^0.1.0 and added stable subpath exports for each public module and modifier |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["RegisterSchema(schemaId, options?)"] --> B["getTablesForSchema(schemaId)"]
    B --> C["buildSchemaDefinition(tables)"]
    C --> D{"metadata.tenantScoped?"}
    D -- "true" --> E["tenantScoped: true in SchemaDefinition"]
    D -- "false" --> F["tenantScoped: undefined in SchemaDefinition"]
    E --> G["new Schema(schemaId, definition, options)"]
    F --> G
    G --> H["insertAllFixtureData(schema, tables) — Promise.all"]
    H --> I{"generator defined?"}
    I -- "no" --> J["return (no-op)"]
    I -- "yes" --> K{"tenantScoped?"}
    K -- "true" --> L["assert fails — throw AssertionError"]
    K -- "false" --> M["schema.instance().table(name).count()"]
    M --> N{"count > 0?"}
    N -- "yes" --> O["skip — already seeded"]
    N -- "no" --> P["schema.instance().table(name).insert(payload)"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/tests/model.test.ts`, line 138-155 ([link](https://github.com/antelopejs/interface-database-decorators/blob/8d6e6b6830652e6b01d6b783c65ff2bd88d7bd18/src/tests/model.test.ts#L138-L155)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Double `RegisterSchema` call is now a no-op and the test exercises a semantically different path**

   The original test called `CreateDatabaseSchemaInstance` twice with different instance IDs to prove that `GetModel` differentiates by instance ID. After the refactor, both `RegisterSchema` calls register the same schema (the second is redundant), and the string arguments passed to `GetModel` are now interpreted as tenant IDs on a table not decorated with `@TenantScoped()`. The test still passes because the cache keys differ, but it no longer exercises the stated scenario.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/tests/model.test.ts
   Line: 138-155

   Comment:
   **Double `RegisterSchema` call is now a no-op and the test exercises a semantically different path**

   The original test called `CreateDatabaseSchemaInstance` twice with different instance IDs to prove that `GetModel` differentiates by instance ID. After the refactor, both `RegisterSchema` calls register the same schema (the second is redundant), and the string arguments passed to `GetModel` are now interpreted as tenant IDs on a table not decorated with `@TenantScoped()`. The test still passes because the cache keys differ, but it no longer exercises the stated scenario.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/tests/model.test.ts:125-140
**Cache test passes a string TenantId to a non-tenant-scoped table**

`GetModelFromCacheTest` registers a plain (non-`@TenantScoped()`) table yet calls `GetModel(TestModel, "test-model-cache-db")`, where `"test-model-cache-db"` is now typed as `TenantId` and forwarded to `schema.instance("test-model-cache-db")`. The test still validates the caching contract (same key → same object reference) because the mock adapter tolerates the call, but it exercises an undefined code path for non-tenant-scoped tables. Adding `@TenantScoped()` to `TestTable` here (mirroring what `CreateNewModelWhenNotCachedTest` does) would make the intent unambiguous.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: distinguish undefined from empty-st..."](https://github.com/antelopejs/interface-database-decorators/commit/f5c2d671576435e9cb09bcc496bc42d6a3534e95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31495333)</sub>

<!-- /greptile_comment -->