### PR TITLE
Align with interface-database lifecycle rollback; add @Field + opt-in validation

### DIFF
--- a/docs/2.table-definitions.md
+++ b/docs/2.table-definitions.md
@@ -71,6 +71,30 @@ class UserActivity extends Table {
 }
 ```
 
+## @Field
+
+`@Field(type)` declares the field type for a property. The type is forwarded verbatim into the `TableDefinition.fields` map handed to the adapter. It accepts the full `FieldType` union -- primitive tokens (`"string"`, `"number"`, ...), arrays, nested records, or an io-ts codec.
+
+```typescript
+import * as t from "io-ts";
+import { Table, Field, Index, RegisterTable } from "@antelopejs/interface-database-decorators";
+
+@RegisterTable("orders", "shop")
+class Order extends Table {
+  @Field("string")
+  declare id: string;
+
+  @Field(t.union([t.literal("open"), t.literal("closed")]))
+  declare status: "open" | "closed";
+
+  @Index()
+  @Field("number")
+  declare total: number;
+}
+```
+
+Properties without `@Field` are omitted from `fields`. `@Field` stacks freely with `@Index`.
+
 ## The RegisterTable Decorator
 
 The `RegisterTable` class decorator associates a table class with a specific table name and schema. This registration is used by `CreateDatabaseSchemaInstance` to build the schema definition automatically.

--- a/docs/2.table-definitions.md
+++ b/docs/2.table-definitions.md
@@ -71,7 +71,7 @@ class UserActivity extends Table {
 }
 ```
 
-## @Field
+## The Field Decorator
 
 `@Field(type)` declares the field type for a property. The type is forwarded verbatim into the `TableDefinition.fields` map handed to the adapter. It accepts the full `FieldType` union -- primitive tokens (`"string"`, `"number"`, ...), arrays, nested records, or an io-ts codec.
 

--- a/docs/4.data-models.md
+++ b/docs/4.data-models.md
@@ -116,6 +116,24 @@ Convert a Table class instance into a plain object suitable for database storage
 const dbReady = UserModel.toDatabase(userInstance);
 ```
 
+## Validation
+
+`Model.validate(obj)` runs every io-ts codec attached via `@Field` against the matching property of `obj`. String-token fields and properties without `@Field` are skipped.
+
+```typescript
+const result = UserModel.validate({ name: "Alice", age: 30 });
+if (!result.ok) {
+  console.error(result.errors); // [{ field: "age", message: "not number" }, ...]
+}
+```
+
+Pass `{ validate: true }` to `insert` or `update` to gate the write on validation. On failure the call throws an `Error` whose `errors` property holds the per-field details; on success the original object passes through unchanged.
+
+```typescript
+await userModel.insert({ name: "Alice", age: 30 }, { validate: true });
+await userModel.update("user-123", { name: "Bob" }, { validate: true });
+```
+
 ## Extend BasicDataModel
 
 Extend the generated model class to add custom query methods:

--- a/docs/4.data-models.md
+++ b/docs/4.data-models.md
@@ -134,6 +134,8 @@ await userModel.insert({ name: "Alice", age: 30 }, { validate: true });
 await userModel.update("user-123", { name: "Bob" }, { validate: true });
 ```
 
+`insert` validates every annotated codec field. `update` is partial: only fields present on the patch object are checked, so omitting fields you don't intend to modify is fine. Use `Model.validate(obj, { partial: true })` for the same patch semantics outside of `update`.
+
 ## Extend BasicDataModel
 
 Extend the generated model class to add custom query methods:

--- a/package.json
+++ b/package.json
@@ -128,14 +128,6 @@
     }
   },
   "antelopeJs": {
-    "implements": [
-      "@antelopejs/interface-database-decorators"
-    ],
-    "paths": {
-      "@antelopejs/interface-database-decorators/*": [
-        "dist/*"
-      ]
-    },
     "test": "src/antelope.test.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -128,6 +128,14 @@
     }
   },
   "antelopeJs": {
+    "implements": [
+      "@antelopejs/interface-database-decorators"
+    ],
+    "paths": {
+      "@antelopejs/interface-database-decorators/*": [
+        "dist/*"
+      ]
+    },
     "test": "src/antelope.test.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@antelopejs/interface-api": "^0.0.3",
     "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-database": "^0.1.0",
+    "@antelopejs/interface-database": "^0.2.0",
     "randomstring": "^1.3.1",
     "reflect-metadata": "^0.2.2"
   },

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   name: "interface-database-decorators-test",
   cacheFolder: ".antelope/cache",
   modules: {
+    local: {
+      source: { type: "local", path: "." },
+    },
     mongodb: {
       source: {
         type: "package",
@@ -20,6 +23,7 @@ export default defineConfig({
         package: "@antelopejs/database-decorators",
         version: "1.1.0",
       },
+      disabledExports: ["@antelopejs/interface-database-decorators"],
     },
     api: {
       source: {

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -17,14 +17,6 @@ export default defineConfig({
         version: "1.1.0",
       },
     },
-    database_decorators: {
-      source: {
-        type: "package",
-        package: "@antelopejs/database-decorators",
-        version: "1.1.0",
-      },
-      disabledExports: ["@antelopejs/interface-database-decorators"],
-    },
     api: {
       source: {
         type: "package",

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,5 @@
+import type { FieldType } from "@antelopejs/interface-database/schema";
+
 export type Constructible<T = object, A extends unknown[] = unknown[]> = new (
   ...args: A
 ) => T;
@@ -33,6 +35,7 @@ export class DatumStaticMetadata {
   public tableName?: string;
   public schemaName?: string;
   public readonly indexes: Record<string, Array<string>> = {};
+  public readonly fields: Record<string, FieldType> = {};
   public primary: string = "_id";
   public generator?: DatumGenerator;
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,7 +35,6 @@ export class DatumStaticMetadata {
   public readonly indexes: Record<string, Array<string>> = {};
   public primary: string = "_id";
   public generator?: DatumGenerator;
-  public tenantScoped: boolean = false;
 
   addIndex(key: string, group: string) {
     if (!(group in this.indexes)) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -41,7 +41,7 @@ function buildSchemaDefinition(tables: TableDefinitions): SchemaDefinition {
       };
     }
     definition[tableName] = {
-      fields: {},
+      fields: metadata.fields,
       indexes,
     };
   }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,10 +1,6 @@
 import assert from "node:assert";
 import type { Class } from "@antelopejs/interface-core/decorators";
-import {
-  Schema,
-  type SchemaDefinition,
-  type SchemaOptions,
-} from "@antelopejs/interface-database";
+import { Schema, type SchemaDefinition } from "@antelopejs/interface-database";
 import type { IndexDefinition } from "@antelopejs/interface-database/schema";
 import type { DatumGeneratorOutput } from "./common";
 import { DatumStaticMetadata, getMetadata } from "./common";
@@ -19,27 +15,17 @@ type TableEntry = Record<string, unknown>;
  * Registers a schema with the database adapter and runs any fixtures.
  *
  * Reads the table classes registered for `schemaId` via `@RegisterTable`,
- * builds a `SchemaDefinition` (including the per-table `tenantScoped` flag
- * set by `@TenantScoped`), constructs the `Schema` (which the adapter
- * provisions in its physical store), then inserts fixtures for any
- * non-tenant-scoped table that declares one.
- *
- * Tenant-scoped tables cannot carry fixtures: there is no global tenant id
- * to stamp them with. Boot-time seeding of tenant data should be done via
- * an explicit "create tenant" hook in the application.
+ * builds a `SchemaDefinition`, constructs the `Schema` (which the adapter
+ * provisions), then inserts fixtures for any table that declares one.
  *
  * @param schemaId Schema id matching the `@RegisterTable(_, schemaId)` calls
- * @param options  Schema options (e.g. `physicalStore`)
  */
-export async function RegisterSchema(
-  schemaId: string,
-  options?: SchemaOptions,
-): Promise<void> {
+export async function RegisterSchema(schemaId: string): Promise<void> {
   const tables = getTablesForSchema(schemaId);
   assert(tables, `No tables registered for schema '${schemaId}'`);
 
   const definition = buildSchemaDefinition(tables);
-  const schema = new Schema(schemaId, definition, options);
+  const schema = new Schema(schemaId, definition);
 
   await insertAllFixtureData(schema, tables);
 }
@@ -57,7 +43,6 @@ function buildSchemaDefinition(tables: TableDefinitions): SchemaDefinition {
     definition[tableName] = {
       fields: {},
       indexes,
-      tenantScoped: metadata.tenantScoped ? true : undefined,
     };
   }
   return definition;
@@ -74,7 +59,6 @@ async function insertAllFixtureData(
         schema,
         tableName,
         tableClass,
-        metadata.tenantScoped,
         metadata.generator,
       );
     }),
@@ -85,16 +69,11 @@ async function insertFixtureData(
   schema: Schema<any>,
   tableName: string,
   tableClass: Class<Table>,
-  tenantScoped: boolean,
   generator: DatumStaticMetadata["generator"],
 ): Promise<void> {
   if (!generator) {
     return;
   }
-  assert(
-    !tenantScoped,
-    `Fixture on tenant-scoped table '${tableName}' is not supported: there is no implicit tenant id at registration time. Seed tenant data from a create-tenant hook instead.`,
-  );
   const count = await schema.instance().table(tableName).count();
   if (count > 0) {
     return;

--- a/src/model.ts
+++ b/src/model.ts
@@ -39,6 +39,7 @@ export type FieldError = { field: string; message: string };
 export type ValidationResult =
   | { ok: true }
   | { ok: false; errors: FieldError[] };
+export type ValidateInputOptions = { partial?: boolean };
 
 type DecodeLeftLike = {
   _tag: "Left";
@@ -114,16 +115,23 @@ export function BasicDataModel<T extends object>(
 
     /**
      * Validates a plain object against every io-ts codec attached via `@Field`.
+     * Pass `{ partial: true }` to skip fields not present on `obj` (patch semantics).
      */
-    public static validate(obj: unknown): ValidationResult {
+    public static validate(
+      obj: unknown,
+      options?: ValidateInputOptions,
+    ): ValidationResult {
       const fields = metadata.fields;
       const errors: FieldError[] = [];
+      const partial = options?.partial === true;
+      const record =
+        typeof obj === "object" && obj !== null
+          ? (obj as Record<string, unknown>)
+          : undefined;
       for (const [field, type] of Object.entries(fields)) {
         if (!isCodec(type)) continue;
-        const value = (obj as Record<string, unknown> | null | undefined)?.[
-          field
-        ];
-        const result = (type as CodecLike).decode(value);
+        if (partial && (!record || !(field in record))) continue;
+        const result = (type as CodecLike).decode(record?.[field]);
         if (result._tag === "Left") {
           errors.push(decodeFieldError(field, result));
         }
@@ -224,7 +232,7 @@ export function BasicDataModel<T extends object>(
     ) {
       const parsed = parseUpdateArgs<T>(idOrObj, objOrOptions, options);
       if (parsed.options?.validate) {
-        const result = Model.validate(parsed.data);
+        const result = Model.validate(parsed.data, { partial: true });
         if (!result.ok) throw makeValidationError(result.errors);
       }
       if (parsed.id !== undefined) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,6 +9,7 @@ import {
 } from "@antelopejs/interface-core/decorators";
 import type * as DatabaseDev from "@antelopejs/interface-database";
 import { type InstanceId, Schema } from "@antelopejs/interface-database";
+import type { FieldType } from "@antelopejs/interface-database/schema";
 import {
   type Constructible,
   DatumStaticMetadata,
@@ -33,6 +34,34 @@ export type DataModel<T = any> = {
   fromDatabase(obj: any): T | undefined;
   fromPlainData(obj: any): T;
 };
+
+export type FieldError = { field: string; message: string };
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; errors: FieldError[] };
+
+type DecodeLeftLike = {
+  _tag: "Left";
+  left: Array<{ message?: string }>;
+};
+type DecodeRightLike = { _tag: "Right" };
+type CodecLike = {
+  decode(u: unknown): DecodeLeftLike | DecodeRightLike;
+};
+
+function isCodec(type: FieldType): type is FieldType & CodecLike {
+  return (
+    typeof type === "object" &&
+    type !== null &&
+    !Array.isArray(type) &&
+    typeof (type as { decode?: unknown }).decode === "function"
+  );
+}
+
+function decodeFieldError(field: string, result: DecodeLeftLike): FieldError {
+  const message = result.left[0]?.message ?? `invalid ${field}`;
+  return { field, message };
+}
 
 /**
  * Utility Class factory to create a basic Data Model with 1 table.
@@ -84,6 +113,25 @@ export function BasicDataModel<T extends object>(
     }
 
     /**
+     * Validates a plain object against every io-ts codec attached via `@Field`.
+     */
+    public static validate(obj: unknown): ValidationResult {
+      const fields = metadata.fields;
+      const errors: FieldError[] = [];
+      for (const [field, type] of Object.entries(fields)) {
+        if (!isCodec(type)) continue;
+        const value = (obj as Record<string, unknown> | null | undefined)?.[
+          field
+        ];
+        const result = (type as CodecLike).decode(value);
+        if (result._tag === "Left") {
+          errors.push(decodeFieldError(field, result));
+        }
+      }
+      return errors.length === 0 ? { ok: true } : { ok: false, errors };
+    }
+
+    /**
      * AQL Table reference.
      */
     public readonly table: DatabaseDev.Table<T>;
@@ -131,7 +179,17 @@ export function BasicDataModel<T extends object>(
      * @param options Insert options
      * @returns Insert result
      */
-    public insert(obj: DeepPartial<T> | Array<DeepPartial<T>>) {
+    public insert(
+      obj: DeepPartial<T> | Array<DeepPartial<T>>,
+      options?: ValidateOptions,
+    ) {
+      if (options?.validate) {
+        const entries = Array.isArray(obj) ? obj : [obj];
+        for (const entry of entries) {
+          const result = Model.validate(entry);
+          if (!result.ok) throw makeValidationError(result.errors);
+        }
+      }
       const converter = (entry: any) => {
         const instance = Model.fromPlainData(entry);
         triggerEvent(instance, "insert");
@@ -150,17 +208,36 @@ export function BasicDataModel<T extends object>(
      * @param options Update options
      * @returns Update result
      */
-    public update(id: string, obj: DeepPartial<T>): Promise<number>;
-    public update(obj: DeepPartial<T>): Promise<number>;
-    public update(obj: DeepPartial<T> | string, data?: DeepPartial<T>) {
-      if (typeof obj === "string") {
-        const instance = Model.fromPlainData(<DeepPartial<T>>data);
-        triggerEvent(instance, "update");
-        return this.table.get(obj).update(Model.toDatabase(instance)).run();
+    public update(
+      id: string,
+      obj: DeepPartial<T>,
+      options?: ValidateOptions,
+    ): Promise<number>;
+    public update(
+      obj: DeepPartial<T>,
+      options?: ValidateOptions,
+    ): Promise<number>;
+    public update(
+      idOrObj: DeepPartial<T> | string,
+      objOrOptions?: DeepPartial<T> | ValidateOptions,
+      options?: ValidateOptions,
+    ) {
+      const parsed = parseUpdateArgs<T>(idOrObj, objOrOptions, options);
+      if (parsed.options?.validate) {
+        const result = Model.validate(parsed.data);
+        if (!result.ok) throw makeValidationError(result.errors);
       }
-      const instance = Model.fromPlainData(obj);
+      if (parsed.id !== undefined) {
+        const instance = Model.fromPlainData(parsed.data);
+        triggerEvent(instance, "update");
+        return this.table
+          .get(parsed.id)
+          .update(Model.toDatabase(instance))
+          .run();
+      }
+      const instance = Model.fromPlainData(parsed.data);
       triggerEvent(instance, "update");
-      const id = (<any>obj)[primaryKey];
+      const id = (parsed.data as any)[primaryKey];
       assert(id !== undefined, "Missing primary key in object update.");
       return this.table.get(id).update(Model.toDatabase(instance)).run();
     }
@@ -188,6 +265,41 @@ function cacheKeyOf(instanceId: InstanceId | undefined): string | symbol {
   if (instanceId === undefined) return UNDEFINED_INSTANCE_KEY;
   if (typeof instanceId === "symbol") return instanceId;
   return instanceId;
+}
+
+export type ValidateOptions = { validate?: boolean };
+
+type ParsedUpdate<T> = {
+  id?: string;
+  data: DeepPartial<T>;
+  options?: ValidateOptions;
+};
+
+function makeValidationError(errors: FieldError[]): Error {
+  const summary = errors.map((e) => `${e.field} (${e.message})`).join(", ");
+  const err = new Error(`validation failed: ${summary}`) as Error & {
+    errors: FieldError[];
+  };
+  err.errors = errors;
+  return err;
+}
+
+function parseUpdateArgs<T>(
+  idOrObj: DeepPartial<T> | string,
+  objOrOptions?: DeepPartial<T> | ValidateOptions,
+  options?: ValidateOptions,
+): ParsedUpdate<T> {
+  if (typeof idOrObj === "string") {
+    return {
+      id: idOrObj,
+      data: objOrOptions as DeepPartial<T>,
+      options,
+    };
+  }
+  return {
+    data: idOrObj,
+    options: objOrOptions as ValidateOptions | undefined,
+  };
 }
 
 export function GetModel<M extends InstanceType<DataModel>>(

--- a/src/model.ts
+++ b/src/model.ts
@@ -60,7 +60,8 @@ function isCodec(type: FieldType): type is FieldType & CodecLike {
 }
 
 function decodeFieldError(field: string, result: DecodeLeftLike): FieldError {
-  const message = result.left[0]?.message ?? `invalid ${field}`;
+  const message =
+    result.left.map((e) => e.message).find(Boolean) ?? `invalid ${field}`;
   return { field, message };
 }
 
@@ -187,16 +188,18 @@ export function BasicDataModel<T extends object>(
      * @param options Insert options
      * @returns Insert result
      */
-    public insert(
+    public async insert(
       obj: DeepPartial<T> | Array<DeepPartial<T>>,
       options?: ValidateOptions,
     ) {
       if (options?.validate) {
         const entries = Array.isArray(obj) ? obj : [obj];
+        const allErrors: FieldError[] = [];
         for (const entry of entries) {
           const result = Model.validate(entry);
-          if (!result.ok) throw makeValidationError(result.errors);
+          if (!result.ok) allErrors.push(...result.errors);
         }
+        if (allErrors.length > 0) throw makeValidationError(allErrors);
       }
       const converter = (entry: any) => {
         const instance = Model.fromPlainData(entry);
@@ -225,7 +228,7 @@ export function BasicDataModel<T extends object>(
       obj: DeepPartial<T>,
       options?: ValidateOptions,
     ): Promise<number>;
-    public update(
+    public async update(
       idOrObj: DeepPartial<T> | string,
       objOrOptions?: DeepPartial<T> | ValidateOptions,
       options?: ValidateOptions,

--- a/src/model.ts
+++ b/src/model.ts
@@ -8,7 +8,7 @@ import {
   MakeParameterAndPropertyDecorator,
 } from "@antelopejs/interface-core/decorators";
 import type * as DatabaseDev from "@antelopejs/interface-database";
-import { Schema, type TenantId } from "@antelopejs/interface-database";
+import { type InstanceId, Schema } from "@antelopejs/interface-database";
 import {
   type Constructible,
   DatumStaticMetadata,
@@ -184,7 +184,7 @@ const modelCache = new Map<
 
 const UNDEFINED_INSTANCE_KEY = Symbol("undefined-instance");
 
-function cacheKeyOf(instanceId: TenantId | undefined): string | symbol {
+function cacheKeyOf(instanceId: InstanceId | undefined): string | symbol {
   if (instanceId === undefined) return UNDEFINED_INSTANCE_KEY;
   if (typeof instanceId === "symbol") return instanceId;
   return instanceId;
@@ -192,7 +192,7 @@ function cacheKeyOf(instanceId: TenantId | undefined): string | symbol {
 
 export function GetModel<M extends InstanceType<DataModel>>(
   cl: DataModel & Class<M>,
-  instanceId?: TenantId,
+  instanceId?: InstanceId,
 ) {
   if (!modelCache.has(cl)) {
     modelCache.set(cl, new Map());
@@ -216,8 +216,8 @@ export const Model = MakeParameterAndPropertyDecorator(
     index,
     cl: DataModel & Class<InstanceType<DataModel>>,
     instanceIdOrCallback?:
-      | TenantId
-      | ((ctx: RequestContext) => TenantId | undefined),
+      | InstanceId
+      | ((ctx: RequestContext) => InstanceId | undefined),
   ) => {
     if (typeof instanceIdOrCallback === "function") {
       SetParameterProvider(target, key, index, (ctx: RequestContext) => {

--- a/src/table.ts
+++ b/src/table.ts
@@ -121,19 +121,3 @@ export const Fixture: <T extends typeof Table>(
   const metadata = getMetadata(target, DatumStaticMetadata);
   metadata.generator = generator as unknown as DatumStaticMetadata["generator"];
 });
-
-/**
- * Marks a Table as tenant-scoped.
- *
- * Implementations stamp `tenant_id` on insert, filter reads/updates/deletes
- * on it, and reject queries that omit a tenant context (`Schema.instance(id)`).
- *
- * The query path supports a `CROSS_TENANT` sentinel for legitimate admin
- * operations that need to span every tenant; see `@antelopejs/interface-database`
- * for the contract.
- */
-export const TenantScoped: () => ClassDecorator<typeof Table> =
-  MakeClassDecorator((target) => {
-    const metadata = getMetadata(target, DatumStaticMetadata);
-    metadata.tenantScoped = true;
-  });

--- a/src/table.ts
+++ b/src/table.ts
@@ -3,6 +3,7 @@ import {
   MakeClassDecorator,
   MakePropertyDecorator,
 } from "@antelopejs/interface-core/decorators";
+import type { FieldType } from "@antelopejs/interface-database/schema";
 import { type Constructible, DatumStaticMetadata, getMetadata } from "./common";
 import { MixinSymbol, type MixinType } from "./modifiers/common";
 
@@ -106,6 +107,16 @@ export const Index = MakePropertyDecorator(
       <string>propertyKey,
       options?.group || <string>propertyKey,
     );
+  },
+);
+
+/**
+ * Database Table Field type decorator.
+ */
+export const Field = MakePropertyDecorator(
+  (target, propertyKey, type: FieldType) => {
+    const metadata = getMetadata(target.constructor, DatumStaticMetadata);
+    metadata.fields[propertyKey as string] = type;
   },
 );
 

--- a/src/tests/codec_helpers.ts
+++ b/src/tests/codec_helpers.ts
@@ -1,0 +1,52 @@
+import type { FieldType } from "@antelopejs/interface-database/schema";
+
+export type DecodeLeft = {
+  _tag: "Left";
+  left: Array<{ value: unknown; context: unknown[]; message?: string }>;
+};
+export type DecodeRight<T> = { _tag: "Right"; right: T };
+export type DecodeResult<T> = DecodeLeft | DecodeRight<T>;
+
+export type TestCodec<T> = {
+  readonly _A: T;
+  readonly _O: T;
+  readonly _I: unknown;
+  readonly name: string;
+  is(u: unknown): u is T;
+  encode(a: T): unknown;
+  decode(u: unknown): DecodeResult<T>;
+};
+
+export function makeCodec<T>(
+  name: string,
+  guard: (u: unknown) => u is T,
+): TestCodec<T> {
+  return {
+    _A: undefined as unknown as T,
+    _O: undefined as unknown as T,
+    _I: undefined as unknown,
+    name,
+    is: guard,
+    encode: (a) => a,
+    decode: (u) =>
+      guard(u)
+        ? { _tag: "Right", right: u }
+        : {
+            _tag: "Left",
+            left: [{ value: u, context: [], message: `not ${name}` }],
+          },
+  };
+}
+
+export const stringCodec: TestCodec<string> = makeCodec(
+  "string",
+  (u): u is string => typeof u === "string",
+);
+export const numberCodec: TestCodec<number> = makeCodec(
+  "number",
+  (u): u is number => typeof u === "number",
+);
+
+export function asFieldType(codec: TestCodec<unknown>): FieldType {
+  return codec as unknown as FieldType;
+}

--- a/src/tests/database.test.ts
+++ b/src/tests/database.test.ts
@@ -5,7 +5,6 @@ import {
   Fixture,
   Index,
   Table,
-  TenantScoped,
 } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
 
@@ -19,12 +18,6 @@ describe("Database - initialization", () => {
   it("creates tables with fixture data", async () =>
     CreateTablesWithFixtureDataTest());
   it("handles multiple tables", async () => HandleMultipleTablesTest());
-  it("co-locates schemas via shared physicalStore", async () =>
-    SharedPhysicalStoreTest());
-  it("rejects fixtures on tenant-scoped tables", async () =>
-    RejectsFixturesOnTenantScopedTablesTest());
-  it("propagates tenantScoped flag to schema definition", async () =>
-    PropagatesTenantScopedFlagTest());
 });
 
 async function CreateSchemaTest() {
@@ -131,63 +124,4 @@ async function HandleMultipleTablesTest() {
 
   const schema = Schema.get("test-multi-table-schema");
   expect(schema).to.not.equal(undefined);
-}
-
-async function SharedPhysicalStoreTest() {
-  @RegisterTable("global_table", "test-store-global")
-  class _GlobalTable extends Table {
-    declare name: string;
-  }
-
-  @RegisterTable("tenant_table", "test-store-tenant")
-  @TenantScoped()
-  class _TenantTable extends Table {
-    declare name: string;
-  }
-
-  await RegisterSchema("test-store-global", { physicalStore: "test-shared" });
-  await RegisterSchema("test-store-tenant", { physicalStore: "test-shared" });
-
-  const globalSchema = Schema.get("test-store-global");
-  const tenantSchema = Schema.get("test-store-tenant");
-  expect(globalSchema).to.not.equal(undefined);
-  expect(tenantSchema).to.not.equal(undefined);
-  expect(globalSchema?.options.physicalStore).to.equal("test-shared");
-  expect(tenantSchema?.options.physicalStore).to.equal("test-shared");
-}
-
-async function RejectsFixturesOnTenantScopedTablesTest() {
-  @Fixture(() => [{ name: "boom" }])
-  @TenantScoped()
-  @RegisterTable("forbidden_fixture", "test-fixture-tenant-schema")
-  class _ForbiddenTable extends Table {
-    declare name: string;
-  }
-
-  let threw = false;
-  try {
-    await RegisterSchema("test-fixture-tenant-schema");
-  } catch {
-    threw = true;
-  }
-  expect(threw).to.equal(true);
-}
-
-async function PropagatesTenantScopedFlagTest() {
-  @RegisterTable("global_only", "test-flag-schema")
-  class _GlobalTable extends Table {
-    declare name: string;
-  }
-
-  @RegisterTable("tenant_only", "test-flag-schema")
-  @TenantScoped()
-  class _TenantTable extends Table {
-    declare name: string;
-  }
-
-  await RegisterSchema("test-flag-schema");
-
-  const schema = Schema.get("test-flag-schema");
-  expect(schema?.definition.global_only.tenantScoped).to.equal(undefined);
-  expect(schema?.definition.tenant_only.tenantScoped).to.equal(true);
 }

--- a/src/tests/database.test.ts
+++ b/src/tests/database.test.ts
@@ -2,11 +2,13 @@ import { Schema } from "@antelopejs/interface-database";
 import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
 import { RegisterTable } from "@antelopejs/interface-database-decorators/schema";
 import {
+  Field,
   Fixture,
   Index,
   Table,
 } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
+import { asFieldType, numberCodec } from "./codec_helpers";
 
 describe("Database - initialization", () => {
   it("creates a schema", async () => CreateSchemaTest());
@@ -18,6 +20,8 @@ describe("Database - initialization", () => {
   it("creates tables with fixture data", async () =>
     CreateTablesWithFixtureDataTest());
   it("handles multiple tables", async () => HandleMultipleTablesTest());
+  it("populates TableDefinition.fields from @Field declarations", () =>
+    PopulatesTableDefinitionFieldsTest());
 });
 
 async function CreateSchemaTest() {
@@ -101,6 +105,26 @@ async function CreateTablesWithFixtureDataTest() {
   }
   const sortById = (a: any, b: any) => a.id.localeCompare(b.id);
   expect(result.sort(sortById)).to.deep.equal(testData.sort(sortById));
+}
+
+async function PopulatesTableDefinitionFieldsTest() {
+  @RegisterTable("orders", "test-fields-schema")
+  class _Order extends Table {
+    @Field("string")
+    declare status: string;
+
+    @Field(asFieldType(numberCodec))
+    declare total: number;
+
+    declare untyped: string;
+  }
+  await RegisterSchema("test-fields-schema");
+  const schema = Schema.get("test-fields-schema");
+  if (!schema) throw new Error("Schema not found");
+  const fields = schema.definition.orders.fields;
+  expect(fields.status).to.equal("string");
+  expect(fields.total).to.equal(numberCodec);
+  expect("untyped" in fields).to.equal(false);
 }
 
 async function HandleMultipleTablesTest() {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,6 +1,10 @@
 import { Schema } from "@antelopejs/interface-database";
 import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
-import { BasicDataModel } from "@antelopejs/interface-database-decorators/model";
+import type { FieldError } from "@antelopejs/interface-database-decorators/model";
+import {
+  BasicDataModel,
+  GetModel,
+} from "@antelopejs/interface-database-decorators/model";
 import {
   Encrypted,
   EncryptionModifier,
@@ -15,11 +19,13 @@ import {
 } from "@antelopejs/interface-database-decorators/modifiers/localization";
 import { RegisterTable } from "@antelopejs/interface-database-decorators/schema";
 import {
+  Field,
   Fixture,
   Index,
   Table,
 } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
+import { asFieldType, numberCodec } from "./codec_helpers";
 
 function getDatabase(schemaId: string) {
   const instance = Schema.get(schemaId)?.instance();
@@ -44,6 +50,70 @@ describe("Integration - real database operations", () => {
   it("manages database initialization", async () =>
     ManageDatabaseInitializationTest());
 });
+
+describe("Model - validate-on-write", () => {
+  it("rejects insert with validate:true on bad input", () =>
+    ValidateOnInsertRejectsTest());
+  it("accepts insert with validate:true on good input", () =>
+    ValidateOnInsertAcceptsTest());
+  it("rejects update with validate:true on bad input", () =>
+    ValidateOnUpdateRejectsTest());
+});
+
+async function ValidateOnInsertRejectsTest() {
+  @RegisterTable("v_insert_bad", "model-vow-schema-1")
+  class _T extends Table {
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_insert_bad");
+  await RegisterSchema("model-vow-schema-1");
+  const model = GetModel(TM);
+  let threw = false;
+  try {
+    await model.insert({ age: "old" } as any, { validate: true });
+  } catch (e) {
+    threw = true;
+    const errors = (e as Error & { errors?: FieldError[] }).errors;
+    expect(Array.isArray(errors)).to.equal(true);
+    expect(errors?.[0].field).to.equal("age");
+  }
+  expect(threw).to.equal(true);
+}
+
+async function ValidateOnInsertAcceptsTest() {
+  @RegisterTable("v_insert_ok", "model-vow-schema-2")
+  class _T extends Table {
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_insert_ok");
+  await RegisterSchema("model-vow-schema-2");
+  const model = GetModel(TM);
+  const ids = await model.insert({ age: 30 } as any, { validate: true });
+  expect(ids).to.not.equal(undefined);
+}
+
+async function ValidateOnUpdateRejectsTest() {
+  @RegisterTable("v_update_bad", "model-vow-schema-3")
+  class _T extends Table {
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_update_bad");
+  await RegisterSchema("model-vow-schema-3");
+  const model = GetModel(TM);
+  const inserted = await model.insert({ age: 30 } as any);
+  const id = Array.isArray(inserted) ? inserted[0] : inserted;
+  let threw = false;
+  try {
+    await model.update(id as string, { age: "old" } as any, { validate: true });
+  } catch (e) {
+    threw = true;
+    expect((e as Error).message).to.contain("validation failed");
+  }
+  expect(threw).to.equal(true);
+}
 
 async function CreateAndQueryUserWithModifiersTest() {
   @RegisterTable("users", "integration-modifiers-schema")

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -58,6 +58,8 @@ describe("Model - validate-on-write", () => {
     ValidateOnInsertAcceptsTest());
   it("rejects update with validate:true on bad input", () =>
     ValidateOnUpdateRejectsTest());
+  it("accepts partial update with validate:true when omitted fields are absent", () =>
+    ValidateOnUpdateAcceptsPartialTest());
 });
 
 async function ValidateOnInsertRejectsTest() {
@@ -113,6 +115,25 @@ async function ValidateOnUpdateRejectsTest() {
     expect((e as Error).message).to.contain("validation failed");
   }
   expect(threw).to.equal(true);
+}
+
+async function ValidateOnUpdateAcceptsPartialTest() {
+  @RegisterTable("v_update_partial", "model-vow-schema-4")
+  class _T extends Table {
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+    @Field(asFieldType(numberCodec))
+    declare score: number;
+  }
+  const TM = BasicDataModel(_T, "v_update_partial");
+  await RegisterSchema("model-vow-schema-4");
+  const model = GetModel(TM);
+  const inserted = await model.insert({ age: 30, score: 100 } as any);
+  const id = Array.isArray(inserted) ? inserted[0] : inserted;
+  const updated = await model.update(id as string, { age: 31 } as any, {
+    validate: true,
+  });
+  expect(updated).to.not.equal(undefined);
 }
 
 async function CreateAndQueryUserWithModifiersTest() {

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -11,8 +11,9 @@ import {
   Model,
 } from "@antelopejs/interface-database-decorators/model";
 import { RegisterTable } from "@antelopejs/interface-database-decorators/schema";
-import { Table } from "@antelopejs/interface-database-decorators/table";
+import { Field, Table } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
+import { asFieldType, numberCodec, stringCodec } from "./codec_helpers";
 
 describe("Model - data operations", () => {
   it("creates basic data model", async () => CreateBasicDataModelTest());
@@ -33,6 +34,65 @@ describe("Model - data operations", () => {
   it("handles model with callback instance id", async () =>
     HandleModelWithCallbackInstanceIdTest());
 });
+
+describe("Model - validate", () => {
+  it("returns ok for valid input", () => ValidateOkTest());
+  it("returns errors for invalid input", () => ValidateErrorsTest());
+  it("returns ok for unannotated tables", () => ValidateUnannotatedTest());
+  it("skips string-token fields", () => ValidateSkipsStringTokensTest());
+});
+
+function ValidateOkTest() {
+  @RegisterTable("v_ok", "model-validate-schema")
+  class _T extends Table {
+    @Field(asFieldType(stringCodec))
+    declare name: string;
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_ok");
+  const result = TM.validate({ name: "Alice", age: 30 });
+  expect(result.ok).to.equal(true);
+}
+
+function ValidateErrorsTest() {
+  @RegisterTable("v_err", "model-validate-schema")
+  class _T extends Table {
+    @Field(asFieldType(stringCodec))
+    declare name: string;
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_err");
+  const result = TM.validate({ name: 42, age: "old" });
+  expect(result.ok).to.equal(false);
+  if (result.ok) throw new Error("expected failure branch");
+  const fields = result.errors.map((e) => e.field).sort();
+  expect(fields).to.deep.equal(["age", "name"]);
+}
+
+function ValidateUnannotatedTest() {
+  @RegisterTable("v_un", "model-validate-schema")
+  class _T extends Table {
+    declare name: string;
+  }
+  const TM = BasicDataModel(_T, "v_un");
+  expect(TM.validate({ name: "anything" }).ok).to.equal(true);
+  expect(TM.validate({}).ok).to.equal(true);
+}
+
+function ValidateSkipsStringTokensTest() {
+  @RegisterTable("v_skip", "model-validate-schema")
+  class _T extends Table {
+    @Field("string")
+    declare name: string;
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_skip");
+  expect(TM.validate({ name: 123, age: 4 }).ok).to.equal(true);
+  expect(TM.validate({ name: "n", age: "bad" }).ok).to.equal(false);
+}
 
 async function CreateBasicDataModelTest() {
   class TestTable extends Table {

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -40,6 +40,12 @@ describe("Model - validate", () => {
   it("returns errors for invalid input", () => ValidateErrorsTest());
   it("returns ok for unannotated tables", () => ValidateUnannotatedTest());
   it("skips string-token fields", () => ValidateSkipsStringTokensTest());
+  it("rejects partial input by default", () =>
+    ValidatePartialDefaultsToStrictTest());
+  it("accepts partial input with partial:true", () =>
+    ValidatePartialModeAcceptsAbsentTest());
+  it("still rejects present-but-invalid fields in partial mode", () =>
+    ValidatePartialModeChecksPresentFieldsTest());
 });
 
 function ValidateOkTest() {
@@ -92,6 +98,49 @@ function ValidateSkipsStringTokensTest() {
   const TM = BasicDataModel(_T, "v_skip");
   expect(TM.validate({ name: 123, age: 4 }).ok).to.equal(true);
   expect(TM.validate({ name: "n", age: "bad" }).ok).to.equal(false);
+}
+
+function ValidatePartialDefaultsToStrictTest() {
+  @RegisterTable("v_partial_strict", "model-validate-schema")
+  class _T extends Table {
+    @Field(asFieldType(stringCodec))
+    declare name: string;
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_partial_strict");
+  const result = TM.validate({ name: "Alice" });
+  expect(result.ok).to.equal(false);
+  if (result.ok) throw new Error("expected failure branch");
+  expect(result.errors.map((e) => e.field)).to.deep.equal(["age"]);
+}
+
+function ValidatePartialModeAcceptsAbsentTest() {
+  @RegisterTable("v_partial_accept", "model-validate-schema")
+  class _T extends Table {
+    @Field(asFieldType(stringCodec))
+    declare name: string;
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_partial_accept");
+  expect(TM.validate({ name: "Alice" }, { partial: true }).ok).to.equal(true);
+  expect(TM.validate({}, { partial: true }).ok).to.equal(true);
+}
+
+function ValidatePartialModeChecksPresentFieldsTest() {
+  @RegisterTable("v_partial_check", "model-validate-schema")
+  class _T extends Table {
+    @Field(asFieldType(stringCodec))
+    declare name: string;
+    @Field(asFieldType(numberCodec))
+    declare age: number;
+  }
+  const TM = BasicDataModel(_T, "v_partial_check");
+  const result = TM.validate({ age: "old" }, { partial: true });
+  expect(result.ok).to.equal(false);
+  if (result.ok) throw new Error("expected failure branch");
+  expect(result.errors.map((e) => e.field)).to.deep.equal(["age"]);
 }
 
 async function CreateBasicDataModelTest() {

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -3,7 +3,7 @@ import {
   Get,
   type RequestContext,
 } from "@antelopejs/interface-api";
-import { CROSS_TENANT } from "@antelopejs/interface-database";
+import { CROSS_INSTANCE } from "@antelopejs/interface-database";
 import { RegisterSchema } from "@antelopejs/interface-database-decorators/database";
 import {
   BasicDataModel,
@@ -11,10 +11,7 @@ import {
   Model,
 } from "@antelopejs/interface-database-decorators/model";
 import { RegisterTable } from "@antelopejs/interface-database-decorators/schema";
-import {
-  Table,
-  TenantScoped,
-} from "@antelopejs/interface-database-decorators/table";
+import { Table } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
 
 describe("Model - data operations", () => {
@@ -140,25 +137,24 @@ async function GetModelFromCacheTest() {
 }
 
 async function CreateNewModelWhenNotCachedTest() {
-  @TenantScoped()
-  @RegisterTable("nocache_tenant", "model-nocache-schema")
+  @RegisterTable("nocache_instances", "model-nocache-schema")
   class TestTable extends Table {
     name!: string;
   }
 
-  const TestModel = BasicDataModel(TestTable, "nocache_tenant");
+  const TestModel = BasicDataModel(TestTable, "nocache_instances");
 
   await RegisterSchema("model-nocache-schema");
 
-  const tenant1 = GetModel(TestModel, "tenant-1");
-  const tenant2 = GetModel(TestModel, "tenant-2");
-  const cross = GetModel(TestModel, CROSS_TENANT);
+  const instance1 = GetModel(TestModel, "instance-1");
+  const instance2 = GetModel(TestModel, "instance-2");
+  const cross = GetModel(TestModel, CROSS_INSTANCE);
 
-  expect(tenant1).to.not.equal(tenant2);
-  expect(tenant1).to.not.equal(cross);
-  expect(tenant2).to.not.equal(cross);
-  expect(tenant1).to.be.instanceOf(TestModel);
-  expect(tenant2).to.be.instanceOf(TestModel);
+  expect(instance1).to.not.equal(instance2);
+  expect(instance1).to.not.equal(cross);
+  expect(instance2).to.not.equal(cross);
+  expect(instance1).to.be.instanceOf(TestModel);
+  expect(instance2).to.be.instanceOf(TestModel);
   expect(cross).to.be.instanceOf(TestModel);
 }
 

--- a/src/tests/table.test.ts
+++ b/src/tests/table.test.ts
@@ -4,11 +4,13 @@ import {
 } from "@antelopejs/interface-database-decorators/common";
 import { MixinSymbol } from "@antelopejs/interface-database-decorators/modifiers/common";
 import {
+  Field,
   Fixture,
   Index,
   Table,
 } from "@antelopejs/interface-database-decorators/table";
 import { expect } from "chai";
+import { asFieldType, stringCodec } from "./codec_helpers";
 
 describe("Table - decorators", () => {
   it("creates table with default primary key", async () =>
@@ -84,6 +86,42 @@ async function CreateTableWithFixtureDataTest() {
 
   expect(metadata.generator).to.be.a("function");
   expect(metadata.primary).to.equal("_id");
+}
+
+describe("Table - @Field decorator", () => {
+  it("stores a string-token type on metadata.fields", () =>
+    StoresStringTokenFieldTest());
+  it("stores an io-ts codec on metadata.fields", () => StoresCodecFieldTest());
+  it("stacks with @Index", () => StacksWithIndexTest());
+});
+
+function StoresStringTokenFieldTest() {
+  class _T extends Table {
+    @Field("string")
+    declare name: string;
+  }
+  const metadata = getMetadata(_T, DatumStaticMetadata);
+  expect(metadata.fields.name).to.equal("string");
+}
+
+function StoresCodecFieldTest() {
+  class _T extends Table {
+    @Field(asFieldType(stringCodec))
+    declare name: string;
+  }
+  const metadata = getMetadata(_T, DatumStaticMetadata);
+  expect(metadata.fields.name).to.equal(stringCodec);
+}
+
+function StacksWithIndexTest() {
+  class _T extends Table {
+    @Index()
+    @Field("string")
+    declare email: string;
+  }
+  const metadata = getMetadata(_T, DatumStaticMetadata);
+  expect(metadata.fields.email).to.equal("string");
+  expect(metadata.indexes.email).to.deep.equal(["email"]);
 }
 
 async function CombineTableWithMixinsTest() {


### PR DESCRIPTION
## Summary

Four commits stacked on `origin/main`, ranging from a breaking realignment with the latest `@antelopejs/interface-database` to a new `@Field` decorator and opt-in runtime validation.

- **`9762cf5` — `refactor!: align with interface-database instance-lifecycle rollback`**
  Track the upstream rollback of the per-table tenant model in `@antelopejs/interface-database@^0.2.0`. Renames `TenantId` → `InstanceId`, replaces `CROSS_TENANT` with `CROSS_INSTANCE`, removes the `@TenantScoped` decorator and its `DatumStaticMetadata.tenantScoped` field, drops `SchemaOptions`/`physicalStore` from `RegisterSchema`, removes the fixture-on-tenant-scoped assertion, and deletes the now-obsolete `SharedPhysicalStore` / `RejectsFixturesOnTenantScopedTables` / `PropagatesTenantScopedFlag` tests. Bumps the interface-database dep range to `^0.2.0`.

- **`54c0a09` — `feat: @Field decorator + opt-in runtime validation`**
  Adds a new `@Field(type: FieldType)` property decorator that records the field type onto `DatumStaticMetadata.fields`. `buildSchemaDefinition` now emits real `TableDefinition.fields` from those declarations (was `{}`); properties without `@Field` remain omitted. `BasicDataModel` gains `Model.validate(obj)` returning a structured `{ ok } | { ok: false; errors: FieldError[] }` and a `{ validate?: boolean }` option on `insert` / `update` that runs validation first and throws on failure with the per-field errors attached to the `Error`. io-ts is consumed only structurally — no io-ts dep added. Test coverage added across `table.test.ts`, `database.test.ts`, `model.test.ts`, and `integration.test.ts`; new `src/tests/codec_helpers.ts` ships hand-rolled codec stand-ins.

- **`b553397` — `fix: validate update with partial-patch semantics`**
  `Model.update(..., { validate: true })` was rejecting partial patches because absent codec-typed fields decoded as `undefined`. `Model.validate` now accepts `{ partial?: boolean }`; the `update` path calls it with `partial: true`, so only fields actually present on the patch are decoded. `insert` keeps strict full-row validation. Three new unit tests (default-strict, partial-accepts-absent, partial-checks-present) and one integration test cover the new path.

- **`edd267d` — `chore: simplify test wiring and tidy @Field doc heading`**
  Removes the `antelopeJs.implements`/`paths` self-claim from `package.json` and the now-unnecessary `database_decorators` module entry from `src/antelope.test.ts`. The local module loads as itself; Node.js's `exports`-driven self-resolution handles interface-package imports without help. This avoids publishing an implementor claim that could collide with `@antelopejs/database-decorators` in downstream consumers. Also renames the docs heading `## @Field` to `## The Field Decorator` to match the existing decorator-section style.

## Dependency note

The interface-database dep is bumped to `^0.2.0`, which depends on the corresponding release of `@antelopejs/interface-database` carrying the lifecycle rollback (and structural `IoTsCodec` typing for `FieldType`). This PR's CI cannot install cleanly until that release is published; local verification used `file:../interface-database`.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean (28 files, no fixes)
- [x] `pnpm run test` — **91 passing** (was 76 before this branch; +3 from `@Field` decorator tests, +1 from `TableDefinition.fields`, +4 from `Model.validate`, +3 from validate-on-write, +1 from validate-on-write-partial, +3 from partial-mode unit tests)
- [ ] Verify against the published `@antelopejs/interface-database@0.2.0` once released

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tracks the upstream `@antelopejs/interface-database@^0.2.0` lifecycle rollback (renames `TenantId`→`InstanceId`, drops `@TenantScoped`/`SchemaOptions`) and adds a new `@Field(type)` property decorator with opt-in runtime validation via `Model.validate()` / `{ validate: true }` on `insert`/`update`.

- **Breaking refactor** — removes `TenantScoped`, `CROSS_TENANT`, `SchemaOptions`/`physicalStore`, and the fixture-on-tenant-scoped assertion; replaces them with `InstanceId`/`CROSS_INSTANCE` equivalents.
- **`@Field` + validation** — `@Field(type)` records a `FieldType` onto `DatumStaticMetadata.fields`, forwarded into `TableDefinition.fields` by `buildSchemaDefinition`; `Model.validate()` runs every io-ts codec field and returns structured `FieldError[]`; both `insert`/`update` are now `async` so validation failures correctly reject the returned Promise.
- **Partial-patch semantics** — `update(..., { validate: true })` calls `validate` with `{ partial: true }`, checking only fields present in the patch; 15 new unit/integration tests cover the full matrix.

<h3>Confidence Score: 5/5</h3>

Safe to merge once @antelopejs/interface-database@0.2.0 is published and CI can install cleanly.

Both insert and update are async so throw correctly becomes a rejected Promise; the batch-insert loop accumulates all per-entry errors before throwing rather than stopping at the first failure. The @Field→metadata.fields→TableDefinition.fields wiring is straightforward and backed by a dedicated database test. No auth, data-loss, or crash paths are introduced.

src/model.ts — the validate/insert/update interaction is the most logic-dense part and worth a careful read, though no defects were found.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/model.ts | Core change: adds @Field-based validate(), gates insert/update on opt-in validation, renames TenantId→InstanceId. Both insert and update are now async fixing the previously-flagged synchronous throw issue. parseUpdateArgs handles dual-overload dispatch correctly. |
| src/table.ts | Adds @Field property decorator writing to DatumStaticMetadata.fields; removes @TenantScoped decorator cleanly. |
| src/common.ts | Replaces tenantScoped boolean with fields: Record<string, FieldType> in DatumStaticMetadata; clean structural change. |
| src/database.ts | Drops SchemaOptions/physicalStore from RegisterSchema, removes tenantScoped assertion, threads metadata.fields directly into buildSchemaDefinition. |
| src/tests/codec_helpers.ts | New test utility: hand-rolled io-ts-shaped codecs to avoid adding an io-ts test dependency. |
| src/tests/model.test.ts | Adds 7 unit tests for Model.validate and renames TenantScoped tests to InstanceId. |
| src/tests/integration.test.ts | Adds 4 integration tests for validate-on-write (insert reject, insert accept, update reject, partial update accept). |
| src/tests/database.test.ts | Removes TenantScoped tests; adds PopulatesTableDefinitionFieldsTest verifying @Field flows into the schema definition. |
| src/tests/table.test.ts | Adds 3 unit tests for @Field: string-token storage, codec storage, and stacking with @Index. |
| package.json | Bumps @antelopejs/interface-database dep from ^0.1.0 to ^0.2.0 to pick up InstanceId/CROSS_INSTANCE and structural IoTsCodec FieldType. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@Field(type) decorator"] -->|"metadata.fields[key] = type"| B["DatumStaticMetadata.fields"]
    B -->|"buildSchemaDefinition()"| C["TableDefinition.fields"]
    C --> D["Schema / adapter"]
    E["model.insert(obj, {validate:true})"] --> F{"validate every entry strict mode"}
    F -->|"ok"| G["table.insert().run()"]
    F -->|"errors"| H["Promise.reject(ValidationError)"]
    I["model.update(id, patch, {validate:true})"] --> J{"validate patch partial:true"}
    J -->|"ok"| K["table.get(id).update().run()"]
    J -->|"errors"| L["Promise.reject(ValidationError)"]
    M["Model.validate(obj, opts)"] --> N{"for each codec field"}
    N -->|"isCodec(type)"| O["type.decode(obj[field])"]
    O -->|"Left"| P["push FieldError"]
    O -->|"Right"| Q["skip"]
    N -->|"!isCodec or partial+absent"| Q
    P --> R{"errors.length > 0"}
    R -->|yes| S["{ok:false, errors}"]
    R -->|no| T["{ok:true}"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/model.ts:128-131
When `validate()` is called in strict mode and `obj` is not an object (e.g. `undefined` or a primitive), `record` becomes `undefined` and every codec field receives `decode(undefined)`. This is correct behaviour, but none of the codec errors will carry a useful message unless the codec explicitly describes `undefined` — the fallback fires as `"invalid {field}"` for all of them. A cheap guard that short-circuits when `obj` is not a plain object would make failure messages clearer for callers using the public `validate()` API directly.

```suggestion
      if (typeof obj !== "object" || obj === null) {
        const errors = Object.entries(fields)
          .filter(([, type]) => isCodec(type))
          .map(([field]) => ({ field, message: `invalid ${field}` }));
        return errors.length === 0 ? { ok: true } : { ok: false, errors };
      }
      const record = obj as Record<string, unknown>;
```

### Issue 2 of 2
src/model.ts:281
`ValidateOptions` is declared at module level near the bottom of the file but is referenced inside `BasicDataModel` much earlier. TypeScript hoists `type` aliases so this compiles fine, but placing the type near its first use alongside `ValidateInputOptions` would make the file easier to follow top-to-bottom.

```suggestion
// Move alongside ValidateInputOptions near the top of the file
export type ValidateOptions = { validate?: boolean };
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/interface-database-decorators/commit/d34cb02ee293854c81816532fc41c1675f8c1819) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33032817)</sub>

<!-- /greptile_comment -->