### PR TITLE
chore(deps): interface deps as bounded peer + dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
-    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
-    "@antelopejs/interface-database": ">=0.1.1 <1.0.0",
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-database": "^0.1.3",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -73,13 +73,13 @@
     "test": "pnpm run build && ajs module test ."
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.3",
-    "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-database": "^0.1.1",
     "randomstring": "^1.3.1",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
+    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-database": ">=0.1.1 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -92,6 +92,11 @@
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-database": ">=0.1.1 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@antelopejs/interface-api':
-        specifier: ^0.0.3
-        version: 0.0.3
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
-      '@antelopejs/interface-database':
-        specifier: ^0.1.1
-        version: 0.1.1
       randomstring:
         specifier: ^1.3.1
         version: 1.3.1
@@ -24,6 +15,15 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
     devDependencies:
+      '@antelopejs/interface-api':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
+      '@antelopejs/interface-database':
+        specifier: '>=0.1.1 <1.0.0'
+        version: 0.1.1
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,14 +16,14 @@ importers:
         version: 0.2.2
     devDependencies:
       '@antelopejs/interface-api':
-        specifier: '>=0.0.3 <1.0.0'
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-core':
-        specifier: '>=0.0.3 <1.0.0'
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
       '@antelopejs/interface-database':
-        specifier: '>=0.1.1 <1.0.0'
-        version: 0.1.1
+        specifier: ^0.1.3
+        version: 0.1.3(@antelopejs/interface-core@0.0.5)
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2
@@ -63,14 +63,18 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api@0.0.3':
-    resolution: {integrity: sha512-64UrrttRAjA1LsXwDskh/UVcXDFpH2+gxJHCT+F8YGLPDJE1XzVUW6/YeG441J+zsFJTnaU6Vlt90TwWumcpCA==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
-  '@antelopejs/interface-database@0.1.1':
-    resolution: {integrity: sha512-b2/fgLhDVSTbr3tXIpKCfnpCGxy2Jwf2qbMPOJ1lxru+ut7ipDbdnNhWbS+doY2BRICuFuJ/IOiRiWYTOrsBsg==}
+  '@antelopejs/interface-database@0.1.3':
+    resolution: {integrity: sha512-tMMrQz0IFz1m82O6vYMU9Jbr2x4ZV/nTwBoViONrDuSZrJona3M1lglFh2F6ltS4LaJTsoUXr+qZGupPz2TGaA==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1398,17 +1402,17 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api@0.0.3':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-core@0.0.3':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.1.1':
+  '@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.5
 
   '@biomejs/biome@2.3.2':
     optionalDependencies:


### PR DESCRIPTION
Move interface deps to bounded peerDependencies + mirror in devDependencies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes the three `@antelopejs/interface-*` packages from direct `dependencies` to `peerDependencies`, mirroring them in `devDependencies` so local development and CI retain them. The version constraints are widened from narrow `^0.x.y` ranges (patch-only) to bounded `>=x.y.z <1.0.0` ranges, giving consumers flexibility while capping exposure below 1.0.0.

- `package.json`: removes the three interface packages from `dependencies`, adds them to `peerDependencies` and `devDependencies` with `>=x.y.z <1.0.0` bounds.
- `pnpm-lock.yaml`: lock entries for the three packages move from `dependencies` to `devDependencies`; resolved versions are unchanged (`0.0.3`, `0.0.3`, `0.1.1`).

<h3>Confidence Score: 5/5</h3>

The change is a clean dependency classification update with no functional code changes; the package will work correctly for consumers who supply the peer dependencies.

Only package.json and the lock file change. The restructuring (direct deps → peer + dev deps) is the correct pattern for interface/plugin packages in this ecosystem. The lock file still pins to the same resolved versions, so CI behaviour is unchanged. No new runtime code paths or logic are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves three @antelopejs/interface-* packages from dependencies to peerDependencies (>=x.y.z <1.0.0 ranges) and mirrors them in devDependencies; randomstring and reflect-metadata remain as direct dependencies. |
| pnpm-lock.yaml | Lock file updated to reflect the three interface packages moving from the dependencies section to devDependencies; resolved versions are unchanged (0.0.3, 0.0.3, 0.1.1). |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (dependencies)"]
        A1["interface-database-decorators"] -->|"dependencies ^0.0.3"| B1["@antelopejs/interface-api"]
        A1 -->|"dependencies ^0.0.3"| C1["@antelopejs/interface-core"]
        A1 -->|"dependencies ^0.1.1"| D1["@antelopejs/interface-database"]
    end

    subgraph After["After (peerDependencies + devDependencies)"]
        A2["interface-database-decorators"]
        A2 -->|"peerDependencies >=0.0.3 <1.0.0"| B2["@antelopejs/interface-api"]
        A2 -->|"peerDependencies >=0.0.3 <1.0.0"| C2["@antelopejs/interface-core"]
        A2 -->|"peerDependencies >=0.1.1 <1.0.0"| D2["@antelopejs/interface-database"]
        A2 -.->|"devDependencies (dev/CI only)"| B2
        A2 -.->|"devDependencies (dev/CI only)"| C2
        A2 -.->|"devDependencies (dev/CI only)"| D2
        Consumer["Consumer App"] -->|"must install peers"| B2
        Consumer -->|"must install peers"| C2
        Consumer -->|"must install peers"| D2
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before (dependencies)"]
        A1["interface-database-decorators"] -->|"dependencies ^0.0.3"| B1["@antelopejs/interface-api"]
        A1 -->|"dependencies ^0.0.3"| C1["@antelopejs/interface-core"]
        A1 -->|"dependencies ^0.1.1"| D1["@antelopejs/interface-database"]
    end

    subgraph After["After (peerDependencies + devDependencies)"]
        A2["interface-database-decorators"]
        A2 -->|"peerDependencies >=0.0.3 <1.0.0"| B2["@antelopejs/interface-api"]
        A2 -->|"peerDependencies >=0.0.3 <1.0.0"| C2["@antelopejs/interface-core"]
        A2 -->|"peerDependencies >=0.1.1 <1.0.0"| D2["@antelopejs/interface-database"]
        A2 -.->|"devDependencies (dev/CI only)"| B2
        A2 -.->|"devDependencies (dev/CI only)"| C2
        A2 -.->|"devDependencies (dev/CI only)"| D2
        Consumer["Consumer App"] -->|"must install peers"| B2
        Consumer -->|"must install peers"| C2
        Consumer -->|"must install peers"| D2
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-database-decorators/commit/3eaaf81463530239eb22a80e0fa61b67389fc515) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37739380)</sub>

<!-- /greptile_comment -->